### PR TITLE
feat: ensure commitlint is working

### DIFF
--- a/.github/workflows/node-lint-and-test-with-coverage.yml
+++ b/.github/workflows/node-lint-and-test-with-coverage.yml
@@ -33,6 +33,10 @@ jobs:
         run: |
           npm ci
           npm test
+      - name: Test commit linting
+        if: ${{ hashFiles('commitlint.config.js') != '' }}
+        run: |
+          echo 'fix: make sure commitlint works' | npx --no-install commitlint
       - name: Save code coverage to artifact
         uses: actions/upload-artifact@v6
         with:

--- a/.github/workflows/node-lint-and-test.yml
+++ b/.github/workflows/node-lint-and-test.yml
@@ -29,3 +29,7 @@ jobs:
         run: |
           npm ci
           npm test
+      - name: Test commit linting
+        if: ${{ hashFiles('commitlint.config.js') != '' }}
+        run: |
+          echo 'fix: make sure commitlint works' | npx --no-install commitlint


### PR DESCRIPTION
Sometimes updates to commitlint have broken our git hook for enforcing [conventional commits](https://conventionalcommits.org). This adds a step to the test workflows which will perform a smoke test with commitlint if a config file is present.